### PR TITLE
Integrate Gemini captioning

### DIFF
--- a/src/loop_controller.py
+++ b/src/loop_controller.py
@@ -4,7 +4,6 @@ Dry-run recursive loop controller (I-T-I, T-I-T, etc.) that produces placeholder
 Stores outputs in results/exp_name/<identifier>/
 """
 import os
-import json
 import shutil
 import errno
 from glob import glob

--- a/src/prompt_engine.py
+++ b/src/prompt_engine.py
@@ -1,12 +1,35 @@
 import os
+from typing import Optional
 
+import google.generativeai as genai
 from PIL import Image
 
 
+def _caption_with_gemini(image_path: str) -> Optional[str]:
+    """Return a caption for *image_path* using Gemini if available."""
+
+    api_key = os.getenv("GOOGLE_API_KEY")
+    if not api_key:
+        return None
+
+    try:
+        genai.configure(api_key=api_key)
+        model = genai.GenerativeModel("gemini-pro-vision")
+        img = Image.open(image_path)
+        response = model.generate_content([img, "Describe the image in one sentence."])
+        return response.text.strip()
+    except Exception:
+        # Any failure falls back to placeholder caption
+        return None
+
+
 def generate_caption(image_path: str) -> str:
-    """
-    Fake caption generator that returns a placeholder string.
-    """
+    """Return a caption for *image_path* using Gemini if configured."""
+
+    caption = _caption_with_gemini(image_path)
+    if caption:
+        return caption
+
     image_name = os.path.basename(image_path)
     return f"This is a placeholder caption for {image_name}"
 

--- a/tests/test_prompt_engine.py
+++ b/tests/test_prompt_engine.py
@@ -1,3 +1,8 @@
+import types
+
+from PIL import Image
+
+import prompt_engine
 from prompt_engine import generate_caption, generate_image
 
 
@@ -6,6 +11,30 @@ def test_generate_caption_contains_filename(tmp_path):
     (tmp_path / "some_image.jpg").write_text("dummy")
     caption = generate_caption(fake_path)
     assert "some_image.jpg" in caption
+
+
+def test_generate_caption_with_gemini(monkeypatch, tmp_path):
+    img_path = tmp_path / "img.jpg"
+    Image.new("RGB", (2, 2)).save(img_path)
+
+    class DummyResponse:
+        text = "a test caption"
+
+    class DummyModel:
+        def generate_content(self, parts):
+            return DummyResponse()
+
+    monkeypatch.setenv("GOOGLE_API_KEY", "dummy")
+    monkeypatch.setattr(
+        prompt_engine, "genai",
+        types.SimpleNamespace(
+            configure=lambda api_key=None: None,
+            GenerativeModel=lambda name: DummyModel(),
+        ),
+    )
+
+    caption = generate_caption(str(img_path))
+    assert caption == "a test caption"
 
 
 def test_generate_image_dimensions():

--- a/tests/test_text_start.py
+++ b/tests/test_text_start.py
@@ -1,4 +1,3 @@
-import os
 import json
 from pathlib import Path
 import pytest


### PR DESCRIPTION
## Summary
- hook up Gemini API for caption generation with a fallback
- add unit test to ensure Gemini invocation can be mocked
- clean unused imports

## Testing
- `ruff check .`
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684687c225288329a206aac20322a4e9