### PR TITLE
Validate num_iterations in BenchmarkConfig

### DIFF
--- a/src/benchmark_config.py
+++ b/src/benchmark_config.py
@@ -118,10 +118,10 @@ class BenchmarkConfig:
 
     @staticmethod
     def _load_loop_config(loop_dict: Dict[str, Any]) -> _LoopConfig:
-        return _LoopConfig(
-            type=loop_dict["type"],
-            num_iterations=int(loop_dict["num_iterations"]),
-        )
+        num = loop_dict.get("num_iterations")
+        if not isinstance(num, int) or num <= 0:
+            raise ValueError("num_iterations must be an integer greater than zero")
+        return _LoopConfig(type=loop_dict["type"], num_iterations=num)
 
     @staticmethod
     def _load_models_config(models_dict: Dict[str, Any]) -> _ModelsConfig:

--- a/tests/test_benchmark_config.py
+++ b/tests/test_benchmark_config.py
@@ -123,3 +123,19 @@ def test_malformed_output_template(tmp_path):
     path.write_text(malformed)
     with pytest.raises(ValueError):
         BenchmarkConfig.from_yaml(str(path))
+
+
+def test_zero_iterations_raises(tmp_path):
+    bad_yaml = VALID_YAML.replace("num_iterations: 3", "num_iterations: 0")
+    path = tmp_path / "zero.yaml"
+    path.write_text(bad_yaml)
+    with pytest.raises(ValueError):
+        BenchmarkConfig.from_yaml(str(path))
+
+
+def test_negative_iterations_raises(tmp_path):
+    bad_yaml = VALID_YAML.replace("num_iterations: 3", "num_iterations: -1")
+    path = tmp_path / "negative.yaml"
+    path.write_text(bad_yaml)
+    with pytest.raises(ValueError):
+        BenchmarkConfig.from_yaml(str(path))


### PR DESCRIPTION
## Summary
- ensure `num_iterations` is a positive integer when loading loop config
- test invalid loop counts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852bb3c94388329b93e0ee646259358