### PR TITLE
Refactor Gemini response parsing

### DIFF
--- a/src/evaluation_engine.py
+++ b/src/evaluation_engine.py
@@ -258,21 +258,16 @@ Text 2: {text2}"""
                 raise ValueError(f"Unknown comparison type: {kind}")
 
             try:
-                # Check if response.text exists and is not None
-                if hasattr(response, "text") and response.text is not None:
-                    response_text = response.text.strip()
-                    # Try to extract JSON from the response text
+                response_text = self._extract_response_text(response)
+                if response_text:
+                    response_text = response_text.strip()
                     try:
-                        # Look for JSON object in the text
                         start_idx = response_text.find("{")
                         end_idx = response_text.rfind("}") + 1
                         if start_idx >= 0 and end_idx > start_idx:
                             json_str = response_text[start_idx:end_idx]
                             result = json.loads(json_str)
-                            # Validate the result has required fields
-                            if isinstance(
-                                result.get("score"), (int, float)
-                            ) and isinstance(result.get("reason"), str):
+                            if isinstance(result.get("score"), (int, float)) and isinstance(result.get("reason"), str):
                                 return {
                                     "score": int(result["score"]),
                                     "reason": result["reason"][:280],
@@ -280,11 +275,9 @@ Text 2: {text2}"""
                     except (json.JSONDecodeError, KeyError, ValueError):
                         pass
 
-                    # Fallback: Try to extract score and reason from text
                     try:
                         words = response_text.lower().split()
-                        # Look for a number 1-5 in the text
-                        score = 3  # default
+                        score = 3
                         for word in words:
                             if word.isdigit() and 1 <= int(word) <= 5:
                                 score = int(word)

--- a/tests/test_evaluation_engine.py
+++ b/tests/test_evaluation_engine.py
@@ -1,5 +1,7 @@
 import json
+import types
 
+import evaluation_engine
 from evaluation_engine import EvaluationEngine
 
 
@@ -33,3 +35,49 @@ def test_engine_creates_ratings(tmp_path, monkeypatch):
     assert ratings_path.is_file()
     data = json.loads(ratings_path.read_text())
     assert data and data[0]["score"] == 5
+
+
+def test_extract_response_text_candidates():
+    eng = EvaluationEngine("foo")
+    resp = types.SimpleNamespace(
+        candidates=[
+            types.SimpleNamespace(
+                content=types.SimpleNamespace(parts=[types.SimpleNamespace(text="hello")])
+            )
+        ]
+    )
+    assert eng._extract_response_text(resp) == "hello"
+
+
+def test_run_rater_uses_extractor(monkeypatch, tmp_path):
+    eng = EvaluationEngine(str(tmp_path))
+    monkeypatch.setenv("GOOGLE_API_KEY", "dummy")
+
+    a = tmp_path / "a.txt"
+    b = tmp_path / "b.txt"
+    a.write_text("A")
+    b.write_text("B")
+
+    dummy_resp = object()
+
+    class DummyModel:
+        def generate_content(self, model, contents):
+            return dummy_resp
+
+    class DummyClient:
+        def __init__(self, api_key):
+            self.models = DummyModel()
+
+    monkeypatch.setattr(evaluation_engine.genai, "Client", DummyClient)
+
+    called = {}
+
+    def fake_extract(self, resp):
+        called["resp"] = resp
+        return '{"score": 4, "reason": "works"}'
+
+    monkeypatch.setattr(EvaluationEngine, "_extract_response_text", fake_extract)
+
+    rating = eng._run_rater("text-text", str(a), str(b))
+    assert called.get("resp") is dummy_resp
+    assert rating == {"score": 4, "reason": "works"}


### PR DESCRIPTION
## Summary
- reuse `_extract_response_text` inside `_run_rater`
- test parsing helpers and that the extractor is used

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6852bb3417d88329b4ec026f3714ebf5