### PR TITLE
Fix image handle usage in captioning

### DIFF
--- a/src/prompt_engine.py
+++ b/src/prompt_engine.py
@@ -26,10 +26,12 @@ def _caption_with_gemini(image_path: str, prompt: str) -> Optional[str]:
         return None
 
     client = genai.Client(api_key=api_key)
-    image = Image.open(image_path)
+
+    with Image.open(image_path) as img:
+        image_data = img.copy()
 
     response = client.models.generate_content(
-        model="gemini-2.0-flash", contents=[image, prompt]
+        model="gemini-2.0-flash", contents=[image_data, prompt]
     )
     return response.text if response and hasattr(response, "text") else None
 

--- a/tests/test_captioning.py
+++ b/tests/test_captioning.py
@@ -14,3 +14,27 @@ def test_generate_caption_no_api_key(test_image, monkeypatch):
     caption = generate_caption(str(test_image), prompt="This is a test prompt")
     assert "placeholder caption" in caption.lower()
     assert test_image.name in caption  # contains filename
+
+
+def test_image_context_manager_used(test_image, mock_google_api, monkeypatch):
+    """Ensure Image.open is used as a context manager."""
+
+    closed = {"flag": False}
+
+    class DummyImage:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            closed["flag"] = True
+
+        def copy(self):
+            return self
+
+    def dummy_open(path):
+        return DummyImage()
+
+    monkeypatch.setattr("prompt_engine.Image.open", dummy_open)
+
+    generate_caption(str(test_image), prompt="Prompt")
+    assert closed["flag"]


### PR DESCRIPTION
## Summary
- ensure prompt engine closes image handle with context manager
- keep image data in memory after closing file
- add regression test for context manager usage

## Testing
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852bb2aa4c883299c1166442c14a180