### PR TITLE
Add pathlib usage and formatting tools

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 24.3.0
+    hooks:
+      - id: black
+  - repo: https://github.com/pycqa/flake8
+    rev: 6.1.0
+    hooks:
+      - id: flake8

--- a/README.md
+++ b/README.md
@@ -17,3 +17,16 @@ RaA is framework to evaluate information fidelity in iterative multimodal transf
  - **Datasets & Protocols**: Integrated data with standardized loops and seed management.
  - **Configurable**: Customize and use with a variety of models, data, and evaluations from a single config file.
  - **Documentation & Reports**: Step‐by‐step guides, example scripts, and analytical reports highlighting patterns of degradation.
+
+### Development
+
+This repository uses `black` and `flake8` for code style checks. Install the
+pre-commit hooks to automatically format and lint code before each commit:
+
+```bash
+pip install pre-commit
+pre-commit install
+```
+
+Running `pre-commit` will apply `black` formatting and run `flake8` on changed
+files.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,3 +12,11 @@ where = ["src"]
 [tool.pytest.ini_options]
 addopts = "-q"
 testpaths = ["tests"]
+
+[tool.black]
+line-length = 88
+target-version = ["py311"]
+
+[tool.flake8]
+max-line-length = 88
+extend-ignore = ["E203", "W503"]

--- a/src/evaluation_engine.py
+++ b/src/evaluation_engine.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import json
 import os
-import pathlib
+from pathlib import Path
 from typing import Any, Dict, List, Literal
 
 from google import genai
@@ -27,7 +27,7 @@ class EvaluationEngine:
     def __init__(
         self, exp_root: str, mode: Literal["llm", "human"] = "llm", config=None
     ) -> None:
-        self.exp_root = pathlib.Path(exp_root)
+        self.exp_root = Path(exp_root)
         self.mode = mode
         self.loop_type = (
             config.loop.type.upper() if config else ""
@@ -40,11 +40,11 @@ class EvaluationEngine:
             self._eval_single_item(item_id, record)
 
     def _eval_single_item(self, item_id: str, rec: Dict[str, str]) -> None:
-        om = OutputManager(os.path.join(self.exp_root, item_id, "eval"))
+        om = OutputManager(self.exp_root / item_id / "eval")
         evals: List[Dict[str, Any]] = []
 
         def _path(rel: str) -> str:
-            return os.path.join(self.exp_root, item_id, rel)
+            return str(self.exp_root / item_id / rel)
 
         iters = [
             k.split("_")[0] for k in rec if k.startswith("iter") and k.endswith("_img")
@@ -193,7 +193,7 @@ Example: {"score": 4, "reason": "The images are highly similar in composition an
         try:
             if kind == "image-image":
                 # Ensure both files exist and can be opened as images
-                if not (os.path.exists(a) and os.path.exists(b)):
+                if not (Path(a).exists() and Path(b).exists()):
                     raise FileNotFoundError(f"Missing image file(s): {a} or {b}")
 
                 with Image.open(a) as img1, Image.open(b) as img2:
@@ -214,10 +214,10 @@ Example: {"score": 4, "reason": "The images are highly similar in composition an
                 text1 = "No text available"
                 text2 = "No text available"
 
-                if os.path.exists(a):
+                if Path(a).exists():
                     with open(a, "r", encoding="utf-8") as f:
                         text1 = f.read().strip()
-                if os.path.exists(b):
+                if Path(b).exists():
                     with open(b, "r", encoding="utf-8") as f:
                         text2 = f.read().strip()
 
@@ -236,11 +236,11 @@ Text 2: {text2}"""
                 else:
                     img_path, txt_path = b, a
 
-                if not os.path.exists(img_path):
+                if not Path(img_path).exists():
                     raise FileNotFoundError(f"Missing image file: {img_path}")
 
                 text = "No text available"
-                if os.path.exists(txt_path):
+                if Path(txt_path).exists():
                     with open(txt_path, "r", encoding="utf-8") as f:
                         text = f.read().strip()
 
@@ -310,7 +310,7 @@ Text 2: {text2}"""
         items: List[str],
     ) -> Dict[str, Any]:
         # Convert absolute paths to relative paths for cleaner output
-        rel_items = [os.path.basename(item) for item in items]
+        rel_items = [Path(item).name for item in items]
         return {
             "item_id": item,
             "step": step,

--- a/src/loop_controller.py
+++ b/src/loop_controller.py
@@ -35,23 +35,23 @@ class LoopController:
         self.rootOM.write_json(self.meta, "metadata.json")
 
     def _run_i_t_i(self) -> None:
-        images = sorted(glob(os.path.join(self.cfg.input_dir, "*.[jp][pn]g")))
+        images = sorted(Path(self.cfg.input_dir).glob("*.[jp][pn]g"))
         if not images:
             raise RuntimeError(f"No .jpg/.png found in {self.cfg.input_dir}")
 
         for path in images:
             stem = Path(path).stem
-            self._process_i_t_i_for_image(path, stem)
+            self._process_i_t_i_for_image(str(path), stem)
 
     def _process_i_t_i_for_image(self, img_path: str, stem: str) -> None:
         om = self.rootOM.subdir(stem)
         record: Dict[str, str] = {}
 
-        dest_input = os.path.join(om.root_dir, "input.jpg")
-        self._link_file(img_path, dest_input)
+        dest_input = om.root_dir / "input.jpg"
+        self._link_file(img_path, str(dest_input))
         record["input"] = "input.jpg"
 
-        current_img_path = dest_input
+        current_img_path = str(dest_input)
         for i in range(1, self.cfg.loop.num_iterations + 1):
             caption = generate_caption(
                 current_img_path, prompt=self.cfg.prompts.caption
@@ -65,28 +65,28 @@ class LoopController:
             om.save_image(generated_img, img_name)
             record[f"iter{i}_img"] = img_name
 
-            current_img_path = os.path.join(om.root_dir, img_name)
+            current_img_path = str(om.root_dir / img_name)
 
         self.meta[stem] = record
 
     def _run_t_i_t(self) -> None:
-        texts = sorted(glob(os.path.join(self.cfg.input_dir, "*.txt")))
+        texts = sorted(Path(self.cfg.input_dir).glob("*.txt"))
         if not texts:
             raise RuntimeError(f"No .txt found in {self.cfg.input_dir}")
 
         for path in texts:
             stem = Path(path).stem
-            self._process_t_i_t_for_text(path, stem)
+            self._process_t_i_t_for_text(str(path), stem)
 
     def _process_t_i_t_for_text(self, txt_path: str, stem: str) -> None:
         om = self.rootOM.subdir(stem)
         record: Dict[str, str] = {}
 
-        dest_input = os.path.join(om.root_dir, "input.txt")
-        self._link_file(txt_path, dest_input)
+        dest_input = om.root_dir / "input.txt"
+        self._link_file(txt_path, str(dest_input))
         record["input"] = "input.txt"
 
-        current_text_path = dest_input
+        current_text_path = str(dest_input)
         for i in range(1, self.cfg.loop.num_iterations + 1):
             with open(current_text_path, "r", encoding="utf-8") as f:
                 text_content = f.read()
@@ -95,33 +95,34 @@ class LoopController:
             om.save_image(generated_img, img_name)
             record[f"iter{i}_img"] = img_name
 
-            img_path = os.path.join(om.root_dir, img_name)
+            img_path = str(om.root_dir / img_name)
             caption = generate_caption(img_path, prompt=self.cfg.prompts.caption)
             txt_name = f"text_iter{i}.txt"
             om.save_text(caption, txt_name)
             record[f"iter{i}_text"] = txt_name
 
-            current_text_path = os.path.join(om.root_dir, txt_name)
+            current_text_path = str(om.root_dir / txt_name)
 
         self.meta[stem] = record
 
     def _link_file(self, src: str, dst: str) -> None:
         """Create a symlink; fall back to copy if symlink fails."""
-        os.makedirs(os.path.dirname(dst), exist_ok=True)
+        dst_path = Path(dst)
+        dst_path.parent.mkdir(parents=True, exist_ok=True)
 
-        if os.path.exists(dst):
+        if dst_path.exists():
             try:
-                os.remove(dst)
+                dst_path.unlink()
             except (PermissionError, OSError):
                 time.sleep(1)
                 try:
-                    os.remove(dst)
+                    dst_path.unlink()
                 except (PermissionError, OSError) as e:
                     print(f"Warning: Could not remove existing file {dst}: {e}")
                     return
 
         try:
-            os.symlink(os.path.abspath(src), dst)
+            os.symlink(os.path.abspath(src), dst_path)
             return
         except (AttributeError, NotImplementedError, OSError) as e:
             if isinstance(e, OSError) and e.errno not in (errno.EEXIST, errno.EPERM):
@@ -130,7 +131,7 @@ class LoopController:
         max_retries = 3
         for attempt in range(max_retries):
             try:
-                shutil.copy2(src, dst)
+                shutil.copy2(src, dst_path)
                 return
             except (PermissionError, OSError) as e:
                 if attempt < max_retries - 1:

--- a/src/output_manager.py
+++ b/src/output_manager.py
@@ -5,7 +5,7 @@ Supports creating sub-managers rooted at results/exp_name/<image_stem>/.
 """
 
 import json
-import os
+from pathlib import Path
 from typing import Any, Dict, List
 
 import yaml
@@ -13,20 +13,19 @@ from PIL import Image
 
 
 class OutputManager:
-    def __init__(self, root_dir: str):
-        self.root_dir = root_dir  # e.g. results/exp_001  OR  results/exp_001/input_0
-        os.makedirs(self.root_dir, exist_ok=True)
+    def __init__(self, root_dir: str | Path):
+        self.root_dir = Path(root_dir)
+        self.root_dir.mkdir(parents=True, exist_ok=True)
 
-    def _full(self, fname: str) -> str:
-        return os.path.join(self.root_dir, fname)
+    def _full(self, fname: str) -> Path:
+        return self.root_dir / fname
 
-    def save_text(self, text: str, fname: str) -> str:
+    def save_text(self, text: str, fname: str) -> Path:
         path = self._full(fname)
-        with open(path, "w", encoding="utf-8") as f:
-            f.write(text)
+        path.write_text(text, encoding="utf-8")
         return path
 
-    def save_image(self, image: Image.Image, fname: str) -> str:
+    def save_image(self, image: Image.Image, fname: str) -> Path:
         path = self._full(fname)
         image.save(path)
         return path
@@ -43,4 +42,4 @@ class OutputManager:
 
     def subdir(self, subfolder: str) -> "OutputManager":
         """Return a new OutputManager rooted at <root_dir>/<subfolder>."""
-        return OutputManager(os.path.join(self.root_dir, subfolder))
+        return OutputManager(self.root_dir / subfolder)


### PR DESCRIPTION
## Summary
- use `Path` objects in output manager and evaluation engine
- prefer pathlib operations in loop controller
- configure black and flake8 in `pyproject.toml`
- add pre-commit with black and flake8
- document development workflow for automatic formatting

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852bb889e2083298d278d15d5166ff4