### PR TITLE
Add embed_asset helper

### DIFF
--- a/src/prompt_engine.py
+++ b/src/prompt_engine.py
@@ -80,3 +80,19 @@ def generate_image(prompt: str, text: str) -> Image.Image:
         raise RuntimeError(f"Failed to decode or open generated image data: {e}") from e
 
     return image
+
+
+def embed_asset(path: str) -> str:
+    """Return the embedded representation for ``path``.
+
+    If *path* points to a text file, this function reads and returns its
+    contents. If it is an image (``.png``, ``.jpg`` or ``.jpeg``), the path
+    itself is returned so callers can reference the file directly.
+    """
+
+    lowered = path.lower()
+    if lowered.endswith(('.png', '.jpg', '.jpeg')):
+        return path
+
+    with open(path, 'r', encoding='utf-8') as f:
+        return f.read()

--- a/tests/test_embed_asset.py
+++ b/tests/test_embed_asset.py
@@ -1,0 +1,16 @@
+import os
+from prompt_engine import embed_asset
+from test_utils import create_mock_image
+
+
+def test_embed_asset_reads_text(tmp_path):
+    txt = tmp_path / "sample.txt"
+    txt.write_text("hello", encoding="utf-8")
+    assert embed_asset(str(txt)) == "hello"
+
+
+def test_embed_asset_returns_image_path(tmp_path):
+    img_path = tmp_path / "img.png"
+    create_mock_image().save(img_path)
+    assert embed_asset(str(img_path)) == str(img_path)
+


### PR DESCRIPTION
## Summary
- implement `embed_asset` in `prompt_engine`
- export via new import in `evaluation_engine`
- adjust evaluation engine client handling
- add tests for new helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d0fd25e308329bc68c9af2599cddf