### PR TITLE
Add autorater visualization utility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ pyYAML == 6.0.2
 pillow == 11.2.1
 pytest == 8.4.0 
 google-genai == 1.19.0
+matplotlib == 3.8.4

--- a/src/autorater_visualizer.py
+++ b/src/autorater_visualizer.py
@@ -1,0 +1,112 @@
+# -*- coding: utf-8 -*-
+"""Utilities for visualizing evaluation results.
+
+This module reads the ``ratings.json`` files produced by
+:class:`EvaluationEngine` and generates charts under each item's ``eval``
+folder. The first visualization implemented is a multi-line plot showing how
+scores evolve over iterations.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, List
+
+import matplotlib.pyplot as plt
+
+
+_METRICS = [
+    "content_correspondence",
+    "compositional_alignment",
+    "fidelity_completeness",
+    "stylistic_congruence",
+    "overall_semantic_intent",
+]
+
+
+class AutoRaterVisualizer:
+    """Create plots from ``ratings.json`` produced by :class:`EvaluationEngine`."""
+
+    def __init__(self, ratings_path: str | Path) -> None:
+        self.ratings_path = Path(ratings_path)
+        self.data: List[Dict] = json.loads(self.ratings_path.read_text())
+
+    # ------------------------------------------------------------------
+    def plot_score_trajectories(self, group_by: str = "comparison_type") -> Path:
+        """Plot metric scores over iteration steps.
+
+        Parameters
+        ----------
+        group_by:
+            Either ``"comparison_type"`` or ``"anchor"``. Entries are grouped
+            by this field and plotted in separate subplots.
+        """
+        if group_by not in {"comparison_type", "anchor"}:
+            raise ValueError("group_by must be 'comparison_type' or 'anchor'")
+
+        groups: Dict[str, List[Dict]] = {}
+        for rec in self.data:
+            groups.setdefault(rec[group_by], []).append(rec)
+
+        n = len(groups)
+        fig, axes = plt.subplots(n, 1, figsize=(7, 4 * n), sharex=True)
+        if n == 1:
+            axes = [axes]
+
+        for ax, (group_val, items) in zip(axes, groups.items()):
+            steps = sorted({rec["step"] for rec in items})
+            for metric in _METRICS:
+                series = []
+                for step in steps:
+                    vals = [rec[metric]["score"] for rec in items if rec["step"] == step]
+                    avg = sum(vals) / len(vals) if vals else float("nan")
+                    series.append(avg)
+                ax.plot(steps, series, marker="o", label=metric.replace("_", " "))
+
+            ax.set_title(f"{group_by}: {group_val}")
+            ax.set_xlabel("Iteration Step")
+            ax.set_ylabel("Score")
+            ax.set_ylim(0, 10)
+            ax.legend(loc="lower right")
+
+        fig.tight_layout()
+        out_path = self.ratings_path.parent / f"score_trajectories_{group_by}.png"
+        fig.savefig(out_path)
+        plt.close(fig)
+        return out_path
+
+
+def generate_visualizations(exp_root: str, group_by: str = "comparison_type") -> None:
+    """Generate visualizations for every item under ``exp_root``.
+
+    Parameters
+    ----------
+    exp_root:
+        Path to the experiment directory that contains item subfolders.
+    group_by:
+        Field to group by when plotting. Passed to
+        :meth:`AutoRaterVisualizer.plot_score_trajectories`.
+    """
+    root = Path(exp_root)
+    for item_dir in root.iterdir():
+        ratings = item_dir / "eval" / "ratings.json"
+        if ratings.is_file():
+            vis = AutoRaterVisualizer(ratings)
+            vis.plot_score_trajectories(group_by=group_by)
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Visualize evaluation results")
+    parser.add_argument("exp_root", help="Experiment root directory")
+    parser.add_argument(
+        "--group-by",
+        choices=["comparison_type", "anchor"],
+        default="comparison_type",
+        dest="group_by",
+        help="Group results by this field",
+    )
+    args = parser.parse_args()
+    generate_visualizations(args.exp_root, group_by=args.group_by)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,11 @@
+from pathlib import Path
+import sys
+
+# Ensure the src directory is on sys.path so tests can import project modules
+SRC_ROOT = Path(__file__).resolve().parents[1] / "src"
+if str(SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(SRC_ROOT))
+# Allow imports like `from test_utils import ...`
+TESTS_ROOT = Path(__file__).resolve().parent
+if str(TESTS_ROOT) not in sys.path:
+    sys.path.insert(0, str(TESTS_ROOT))

--- a/tests/test_evaluation_engine.py
+++ b/tests/test_evaluation_engine.py
@@ -22,6 +22,9 @@ def test_engine_creates_ratings(tmp_path, monkeypatch):
     (item / "image_iter1.jpg").write_text("y", encoding="utf-8")
     (item / "text_iter1.txt").write_text("z", encoding="utf-8")
 
+    # Ensure the EvaluationEngine does not attempt real API calls
+    monkeypatch.setenv("GOOGLE_API_KEY", "dummy")
+
     monkeypatch.setattr(
         EvaluationEngine,
         "_run_rater",

--- a/tests/test_visualizer.py
+++ b/tests/test_visualizer.py
@@ -1,0 +1,42 @@
+import json
+from pathlib import Path
+
+from autorater_visualizer import AutoRaterVisualizer
+
+
+def test_plot_score_trajectories(tmp_path):
+    eval_dir = tmp_path / "item1" / "eval"
+    eval_dir.mkdir(parents=True)
+    data = [
+        {
+            "item_id": "item1",
+            "step": 1,
+            "anchor": "original",
+            "comparison_type": "image-image",
+            "comparison_items": ["a", "b"],
+            "content_correspondence": {"score": 8.0, "reason": ""},
+            "compositional_alignment": {"score": 7.0, "reason": ""},
+            "fidelity_completeness": {"score": 6.0, "reason": ""},
+            "stylistic_congruence": {"score": 5.0, "reason": ""},
+            "overall_semantic_intent": {"score": 4.0, "reason": ""},
+        },
+        {
+            "item_id": "item1",
+            "step": 2,
+            "anchor": "original",
+            "comparison_type": "image-image",
+            "comparison_items": ["c", "d"],
+            "content_correspondence": {"score": 7.5, "reason": ""},
+            "compositional_alignment": {"score": 6.5, "reason": ""},
+            "fidelity_completeness": {"score": 5.5, "reason": ""},
+            "stylistic_congruence": {"score": 4.5, "reason": ""},
+            "overall_semantic_intent": {"score": 3.5, "reason": ""},
+        },
+    ]
+    ratings_file = eval_dir / "ratings.json"
+    ratings_file.write_text(json.dumps(data))
+
+    viz = AutoRaterVisualizer(ratings_file)
+    out_path = viz.plot_score_trajectories()
+    assert out_path.is_file()
+    assert out_path.stat().st_size > 0


### PR DESCRIPTION
## Summary
- add `autorater_visualizer.py` to create score trajectory plots
- make tests package importable and allow importing `test_utils`
- update `test_evaluation_engine` to avoid API calls
- include new tests for the visualizer
- add matplotlib to requirements

## Testing
- `pip install matplotlib==3.8.4`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d169af5d4832997332304d967540f