### PR TITLE
Add interactive rating overview reporting with Altair

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ pillow == 11.2.1
 pytest == 8.4.0 
 google-genai == 1.19.0
 matplotlib == 3.8.4
+pandas == 2.2.2
+altair == 5.2.0

--- a/src/reporting.py
+++ b/src/reporting.py
@@ -1,0 +1,112 @@
+# -*- coding: utf-8 -*-
+"""Generate interactive line charts from ``ratings.json`` files.
+
+This module scans experiment output directories for ``ratings.json`` files,
+flattens the rating metrics, and produces an interactive line chart for each
+image. The resulting visualization is saved as ``line_overview.html`` in the
+corresponding ``eval`` folder.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, List, Sequence
+
+import altair as alt
+import pandas as pd
+
+# Map possible metric keys to canonical metric names.
+_METRIC_KEYS: Dict[str, str] = {
+    "content_correspondence": "content_correspondence",
+    "compositional_alignment": "compositional_alignment",
+    "fidelity_completeness": "fidelity_completeness",
+    "style_consistency": "style_consistency",
+    "stylistic_congruence": "style_consistency",
+    "overall": "overall",
+    "overall_semantic_intent": "overall",
+}
+
+
+def _flatten_records(data: Sequence[Dict]) -> pd.DataFrame:
+    """Flatten raw rating records into a tidy DataFrame."""
+    rows: List[Dict[str, object]] = []
+    for rec in data:
+        step = rec.get("step")
+        comparison_type = rec.get("comparison_type")
+        anchor = rec.get("anchor")
+        for key, metric in _METRIC_KEYS.items():
+            metric_data = rec.get(key)
+            if isinstance(metric_data, dict) and "score" in metric_data:
+                rows.append(
+                    {
+                        "step": step,
+                        "comparison_type": comparison_type,
+                        "anchor": anchor,
+                        "metric": metric,
+                        "score": metric_data["score"],
+                    }
+                )
+    return pd.DataFrame(rows)
+
+
+def _build_chart(df: pd.DataFrame) -> alt.Chart:
+    """Create an Altair line chart from flattened ratings."""
+    base = (
+        alt.Chart(df)
+        .mark_line(point=True)
+        .encode(
+            x=alt.X(
+                "step:O",
+                sort=alt.SortField("step", order="ascending"),
+                title="Step",
+            ),
+            y=alt.Y(
+                "score:Q",
+                title="Score",
+                scale=alt.Scale(domain=[0, 10]),
+            ),
+            color=alt.Color("metric:N", title="Metric"),
+            strokeDash=alt.StrokeDash("anchor:N", title="Anchor"),
+            tooltip=[
+                "step:O",
+                "metric:N",
+                "score:Q",
+                "comparison_type:N",
+                "anchor:N",
+            ],
+        )
+    )
+    facet = base.facet(column=alt.Column("comparison_type:N", title=None))
+    return facet.interactive()
+
+
+def generate_line_overview(exp_root: str | Path) -> None:
+    """Generate ``line_overview.html`` for each image under ``exp_root``."""
+    root = Path(exp_root)
+    for item_dir in root.iterdir():
+        if not item_dir.is_dir():
+            continue
+        ratings_path = item_dir / "eval" / "ratings.json"
+        if not ratings_path.is_file():
+            continue
+        data = json.loads(ratings_path.read_text())
+        df = _flatten_records(data)
+        if df.empty:
+            continue
+        chart = _build_chart(df)
+        chart.save(ratings_path.parent / "line_overview.html")
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Generate interactive line charts from ratings.json files"
+    )
+    parser.add_argument(
+        "exp_root",
+        help="Experiment directory containing image subfolders",
+    )
+    args = parser.parse_args()
+    generate_line_overview(args.exp_root)

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -1,0 +1,47 @@
+import json
+from pathlib import Path
+
+from reporting import generate_line_overview
+
+
+def _write_ratings(path: Path) -> None:
+    data = [
+        {
+            "item_id": "item1",
+            "step": 1,
+            "anchor": "original",
+            "comparison_type": "image-image",
+            "comparison_items": ["a", "b"],
+            "content_correspondence": {"score": 8.0, "reason": ""},
+            "compositional_alignment": {"score": 7.0, "reason": ""},
+            "fidelity_completeness": {"score": 6.0, "reason": ""},
+            "style_consistency": {"score": 5.0, "reason": ""},
+            "overall": {"score": 4.0, "reason": ""},
+        },
+        {
+            "item_id": "item1",
+            "step": 2,
+            "anchor": "previous",
+            "comparison_type": "image-image",
+            "comparison_items": ["c", "d"],
+            "content_correspondence": {"score": 7.5, "reason": ""},
+            "compositional_alignment": {"score": 6.5, "reason": ""},
+            "fidelity_completeness": {"score": 5.5, "reason": ""},
+            "style_consistency": {"score": 4.5, "reason": ""},
+            "overall": {"score": 3.5, "reason": ""},
+        },
+    ]
+    path.write_text(json.dumps(data))
+
+
+def test_generate_line_overview(tmp_path):
+    eval_dir = tmp_path / "item1" / "eval"
+    eval_dir.mkdir(parents=True)
+    ratings_file = eval_dir / "ratings.json"
+    _write_ratings(ratings_file)
+
+    generate_line_overview(tmp_path)
+
+    out_file = eval_dir / "line_overview.html"
+    assert out_file.is_file()
+    assert out_file.stat().st_size > 0


### PR DESCRIPTION
## Summary
- add `reporting.py` to flatten `ratings.json` data and generate interactive Altair line charts per image
- include unit test and requirements for `pandas` and `altair`

## Testing
- `pre-commit run --files requirements.txt src/reporting.py tests/test_reporting.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689482970c54832986f3bc1b4bb1fbd5